### PR TITLE
Add support for variable string sizes in ColumnSchema

### DIFF
--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -21,6 +21,9 @@ from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.admin import schema
 
+_string_pattern = r"^STRING\([0-9]+\)+$"
+_string_array_patter = r"^ARRAY<STRING\([0-9]+\)>+$"
+
 
 class ColumnSchema(schema.InformationSchema):
     """Model for interacting with Spanner column schema table."""
@@ -34,9 +37,6 @@ class ColumnSchema(schema.InformationSchema):
     is_nullable = field.Field(field.String)
     spanner_type = field.Field(field.String)
 
-    string_pattern = "^STRING\([0-9]+\)+$"
-    string_array_patter = "^ARRAY<STRING\([0-9]+\)>+$"
-
     @property
     def nullable(self) -> bool:
         return self.is_nullable == "YES"
@@ -47,9 +47,9 @@ class ColumnSchema(schema.InformationSchema):
             if self.spanner_type == field_type.ddl():
                 return field_type
 
-        if bool(re.match(self.string_pattern, self.spanner_type)):
+        if bool(re.match(_string_pattern, self.spanner_type)):
             return field.String
-        elif bool(re.match(self.string_array_patter, self.spanner_type)):
+        elif bool(re.match(_string_array_patter, self.spanner_type)):
             return field.StringArray
 
         raise error.SpannerError(
@@ -58,8 +58,8 @@ class ColumnSchema(schema.InformationSchema):
 
     @property
     def size(self) -> Union[None, int]:
-        if bool(re.match(self.string_pattern, self.spanner_type)) or bool(
-            re.match(self.string_array_patter, self.spanner_type)
+        if bool(re.match(_string_pattern, self.spanner_type)) or bool(
+            re.match(_string_array_patter, self.spanner_type)
         ):
             # Extract digits from string (i.e. STRING(50) -> 50)
             return int("".join(filter(str.isdigit, self.spanner_type)))

--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -22,7 +22,7 @@ from spanner_orm import field
 from spanner_orm.admin import schema
 
 _string_pattern = r"^STRING\([0-9]+\)+$"
-_string_array_patter = r"^ARRAY<STRING\([0-9]+\)>+$"
+_string_array_pattern = r"^ARRAY<STRING\([0-9]+\)>+$"
 
 
 class ColumnSchema(schema.InformationSchema):
@@ -49,7 +49,7 @@ class ColumnSchema(schema.InformationSchema):
 
         if bool(re.match(_string_pattern, self.spanner_type)):
             return field.String
-        elif bool(re.match(_string_array_patter, self.spanner_type)):
+        elif bool(re.match(_string_array_pattern, self.spanner_type)):
             return field.StringArray
 
         raise error.SpannerError(
@@ -59,7 +59,7 @@ class ColumnSchema(schema.InformationSchema):
     @property
     def size(self) -> Union[None, int]:
         if bool(re.match(_string_pattern, self.spanner_type)) or bool(
-            re.match(_string_array_patter, self.spanner_type)
+            re.match(_string_array_pattern, self.spanner_type)
         ):
             # Extract digits from string (i.e. STRING(50) -> 50)
             return int("".join(filter(str.isdigit, self.spanner_type)))

--- a/spanner_orm/admin/column.py
+++ b/spanner_orm/admin/column.py
@@ -21,8 +21,8 @@ from spanner_orm import error
 from spanner_orm import field
 from spanner_orm.admin import schema
 
-_string_pattern = r"^STRING\([0-9]+\)+$"
-_string_array_pattern = r"^ARRAY<STRING\([0-9]+\)>+$"
+_string_pattern = re.compile(r"^STRING\([0-9]+\)+$")
+_string_array_pattern = re.compile(r"^ARRAY<STRING\([0-9]+\)>+$")
 
 
 class ColumnSchema(schema.InformationSchema):
@@ -47,9 +47,9 @@ class ColumnSchema(schema.InformationSchema):
             if self.spanner_type == field_type.ddl():
                 return field_type
 
-        if bool(re.match(_string_pattern, self.spanner_type)):
+        if bool(_string_pattern.match(self.spanner_type)):
             return field.String
-        elif bool(re.match(_string_array_pattern, self.spanner_type)):
+        elif bool(_string_array_pattern.match(self.spanner_type)):
             return field.StringArray
 
         raise error.SpannerError(
@@ -58,8 +58,8 @@ class ColumnSchema(schema.InformationSchema):
 
     @property
     def size(self) -> Union[None, int]:
-        if bool(re.match(_string_pattern, self.spanner_type)) or bool(
-            re.match(_string_array_pattern, self.spanner_type)
+        if bool(_string_pattern.match(self.spanner_type)) or bool(
+            _string_array_pattern.match(self.spanner_type)
         ):
             # Extract digits from string (i.e. STRING(50) -> 50)
             return int("".join(filter(str.isdigit, self.spanner_type)))

--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -81,7 +81,11 @@ class SpannerMetadata(object):
             condition.equal_to("table_schema", ""),
         )
         for column_row in columns:
-            new_field = field.Field(column_row.field_type, nullable=column_row.nullable)
+            new_field = field.Field(
+                column_row.field_type,
+                nullable=column_row.nullable,
+                size=column_row.size,
+            )
             new_field.name = column_row.column_name
             new_field.position = column_row.ordinal_position
             column_data[column_row.table_name][column_row.column_name] = new_field


### PR DESCRIPTION
* Now when we read back tables from the Spanner API, the internal `Model` of a table will accurately populate the `size` property of fields where `size` is applicable.