### PR TITLE
Fix interleaved tables migration

### DIFF
--- a/spanner_orm/admin/metadata.py
+++ b/spanner_orm/admin/metadata.py
@@ -62,7 +62,7 @@ class SpannerMetadata(object):
                 indexes=indexes[table_name],
                 model_class=klass,
             )
-            klass.meta.finalize()
+            klass.meta.finalize(reregister_model=True)
             models[table_name] = klass
 
         return models

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -59,7 +59,7 @@ class ModelMetadata(object):
         self.relations = dict(relations or {})
         self.table = table or ""
 
-    def finalize(self) -> None:
+    def finalize(self, reregister_model: bool = False) -> None:
         """Finish generating metadata state.
 
     Some metadata depends on having all configuration data set before it can
@@ -83,6 +83,12 @@ class ModelMetadata(object):
 
         for _, relation in self.relations.items():
             relation.origin = self.model_class
+        if reregister_model:
+            try:
+                registry.model_registry().get(self.model_class)
+                registry.model_registry().remove(self.model_class)
+            except error.SpannerError:
+                pass
         registry.model_registry().register(self.model_class)
         self._finalized = True
 

--- a/spanner_orm/registry.py
+++ b/spanner_orm/registry.py
@@ -39,7 +39,7 @@ class Registry(object):
         name_components = reversed(self._name_from_class(to_register).split("."))
         name = None
         for component in name_components:
-            name = name = "{}.{}".format(component, name) if name else component
+            name = "{}.{}".format(component, name) if name else component
             if name not in self._registered:
                 self._registered[name] = RegistryComponent()
             self._registered[name].add(to_register)
@@ -57,6 +57,20 @@ class Registry(object):
                 "Multiple classes match {}, add more specificity".format(name)
             )
         return self._registered[name].references[0]
+
+    def remove(self, name: Union[Type[Any], str]) -> None:
+        if isinstance(name, type):
+            name = self._name_from_class(name)
+
+        name_components = reversed(name.split("."))
+        name = None
+        for component in name_components:
+            name = "{}.{}".format(component, name) if name else component
+            if name not in self._registered:
+                raise error.SpannerError(
+                    "{} was not found, verify it has been registered".format(name)
+                )
+            del self._registered[name]
 
 
 _registry = Registry()


### PR DESCRIPTION
- When creating an interleaved table, backwards migrations are broken because
  of this error: `spanner_orm.error.SpannerError: Multiple classes match
  table_interaction_evidence_model, add more specificity`. This happens because
  schemas are fetched using data from Spanner, which leads to multiple tables
  being registered with the same name, causing conflict when an interleaved
  table's migration is validated.

Solution: When fetching from Spanner, re-register model classes so there's no
conflict.