### PR TITLE
Fix Relationship field for interleaved parent table

### DIFF
--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -55,7 +55,7 @@ class CreateTable(SchemaUpdate):
             for field in self._model.fields.values()
         ]
 
-        # Note: Spanner supports multicolumn forgeign keys (hence the use of keys() & values())
+        # Note: Spanner supports multicolumn foreign keys (hence the use of keys() & values())
         relations = [
             "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {} ({})".format(
                 name,
@@ -64,6 +64,7 @@ class CreateTable(SchemaUpdate):
                 ", ".join(relation_obj._constraints.values()),
             )
             for name, relation_obj in self._model.relations.items()
+            if relation_obj.destination.interleaved != self._model
         ]
 
         relations_ddl = (


### PR DESCRIPTION
- This doesn't require a constraint (its the equivalent of a
  reverse relationship in sqlalchemy / django). Ideally the fix
  can be a general purpose reverse relationship manager, but
  that's lot of work. This unblocks the use of relationship for
  the simple case of interleaved parent-child tables.