### PR TITLE
Frozen CreateTable operation so making changes to schema is actually possible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
-        run: python setup.py install
+        run: pip install -e .[tests]
 
       - name: Test
         run: python setup.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install Dependencies
         run: python setup.py install
 
-      - name: Format
-        run: black --check .
-
       - name: Test
         run: python setup.py test
+
+      - name: Format
+        run: black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install Dependencies
         run: python setup.py install
 
+      - name: Format
+        run: black --check .
+
       - name: Test
         run: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
     include_package_data=True,
     python_requires="~=3.7",
     install_requires=["wheel", "google-cloud-spanner >= 1.6, <2.0.0dev"],
-    tests_require=["absl-py"],
+    tests_require=["absl-py", "black==20.8b1"],
     entry_points={"console_scripts": ["spanner-orm = spanner_orm.admin.scripts:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
     include_package_data=True,
     python_requires="~=3.7",
     install_requires=["wheel", "google-cloud-spanner >= 1.6, <2.0.0dev"],
-    tests_require=["absl-py", "black==20.8b1"],
+    tests_require=["absl-py"],
+    extras_require={
+        "tests": ["black==20.8b1"],
+    },
     entry_points={"console_scripts": ["spanner-orm = spanner_orm.admin.scripts:main"]},
 )

--- a/spanner_orm/admin/migration_executor.py
+++ b/spanner_orm/admin/migration_executor.py
@@ -171,14 +171,14 @@ class MigrationExecutor:
     ) -> List[migration.Migration]:
         """Filters the list of migrations according to the desired conditions.
 
-    Args:
-      migrations: List of migrations to filter
-      migrated: Only add migrations whose migration status matches this flag
-      last_migration: Stop adding migrations to the list after this one is found
+        Args:
+          migrations: List of migrations to filter
+          migrated: Only add migrations whose migration status matches this flag
+          last_migration: Stop adding migrations to the list after this one is found
 
-    Returns:
-      List of filtered migrations
-    """
+        Returns:
+          List of filtered migrations
+        """
         filtered = []
         last_migration_found = False
         for migration_ in migrations:

--- a/spanner_orm/admin/schema.py
+++ b/spanner_orm/admin/schema.py
@@ -24,8 +24,8 @@ from spanner_orm.admin import api
 class InformationSchema(model.Model):
     """Base model for Spanner INFORMATION_SCHEMA tables.
 
-  Note: Writes are disallowed and AdminApi is used for reads.
-  """
+    Note: Writes are disallowed and AdminApi is used for reads.
+    """
 
     @classmethod
     def spanner_api(cls) -> api.SpannerAdminApi:

--- a/spanner_orm/admin/update.py
+++ b/spanner_orm/admin/update.py
@@ -204,8 +204,8 @@ class DropTable(SchemaUpdate):
 class AddColumn(SchemaUpdate):
     """Update for adding a column to an existing table.
 
-  Only supports adding nullable columns
-  """
+    Only supports adding nullable columns
+    """
 
     def __init__(self, table_name: str, column_name: str, field_: field.Field):
         self._table = table_name
@@ -260,8 +260,8 @@ class DropColumn(SchemaUpdate):
 class AlterColumn(SchemaUpdate):
     """Update for altering a column an existing table.
 
-  Only supports changing the nullability of a column
-  """
+    Only supports changing the nullability of a column
+    """
 
     def __init__(self, table_name: str, column_name: str, field_: field.Field):
         self._table = table_name

--- a/spanner_orm/api.py
+++ b/spanner_orm/api.py
@@ -42,17 +42,17 @@ class SpannerReadApi(abc.ABC):
     ) -> CallableReturn:
         """Wraps read-only queries in a read transaction.
 
-    The callable will be executed with the read transaction (Snapshot from
-    the Spanner client library)passed to it as the first argument.
+        The callable will be executed with the read transaction (Snapshot from
+        the Spanner client library)passed to it as the first argument.
 
-    Args:
-      method: The method that will be run in the transaction
-      *args: Positional arguments that will be passed to `method`
-      **kwargs: Keyword arguments that will be passed to `method`
+        Args:
+          method: The method that will be run in the transaction
+          *args: Positional arguments that will be passed to `method`
+          **kwargs: Keyword arguments that will be passed to `method`
 
-    Returns:
-      The return value from `method` will be returned from this method
-    """
+        Returns:
+          The return value from `method` will be returned from this method
+        """
         with self._connection.snapshot(multi_use=True) as snapshot:
             return method(snapshot, *args, **kwargs)
 
@@ -70,20 +70,20 @@ class SpannerWriteApi(abc.ABC):
     ) -> CallableReturn:
         """Wraps read-write queries in a write transaction.
 
-    The callable will be executed with the write transaction passed to it as
-    the first argument. If the transaction aborts (usually because the data
-    the write operation depended on has changed since the start of the
-    transaction), the callable will continue to be retried until success or
-    30 seconds has passed.
+        The callable will be executed with the write transaction passed to it as
+        the first argument. If the transaction aborts (usually because the data
+        the write operation depended on has changed since the start of the
+        transaction), the callable will continue to be retried until success or
+        30 seconds has passed.
 
-    Args:
-      method: The method that will be run in the transaction
-      *args: Positional arguments that will be passed to `method`
-      **kwargs: Keyword arguments that will be passed to `method`
+        Args:
+          method: The method that will be run in the transaction
+          *args: Positional arguments that will be passed to `method`
+          **kwargs: Keyword arguments that will be passed to `method`
 
-    Returns:
-      The return value from `method` will be returned from this method
-    """
+        Returns:
+          The return value from `method` will be returned from this method
+        """
         return self._connection.run_in_transaction(method, *args, **kwargs)
 
 
@@ -148,9 +148,9 @@ def connect(
 
 def from_connection(connection: SpannerConnection, **kwargs) -> SpannerApi:
     """
-  Sets the global spanner_api from the provided connection.
-  :param kwargs: Additional keyword args to pass to SpannerApi class
-  """
+    Sets the global spanner_api from the provided connection.
+    :param kwargs: Additional keyword args to pass to SpannerApi class
+    """
     global _api
     _api = SpannerApi(connection, **kwargs)
     return _api

--- a/spanner_orm/condition.py
+++ b/spanner_orm/condition.py
@@ -52,16 +52,16 @@ class Condition(abc.ABC):
     def key(self, name: str) -> str:
         """Returns the unique parameter name for the given name.
 
-    When a name is used multiple times by different conditions (for instance,
-    we name parameters for the column they are being compared against, so
-    multiple conditions on the same column causes this), we need to generate
-    a unique name to disambiguate between these parameters. We do that by
-    appending a suffix that is based on the number of parameters that have
-    already been added to the query
+        When a name is used multiple times by different conditions (for instance,
+        we name parameters for the column they are being compared against, so
+        multiple conditions on the same column causes this), we need to generate
+        a unique name to disambiguate between these parameters. We do that by
+        appending a suffix that is based on the number of parameters that have
+        already been added to the query
 
-    Args:
-      name: Name of parameter to make unique
-    """
+        Args:
+          name: Name of parameter to make unique
+        """
         if self.suffix:
             return "{name}{suffix}".format(name=name, suffix=self.suffix)
         return name
@@ -69,10 +69,10 @@ class Condition(abc.ABC):
     def params(self) -> Dict[str, Any]:
         """Returns parameters to be used in the SQL query.
 
-    Returns:
-      Dictionary mapping from parameter name to value that should be
-      substituted for that parameter in the SQL query
-    """
+        Returns:
+          Dictionary mapping from parameter name to value that should be
+          substituted for that parameter in the SQL query
+        """
         if not self.model_class:
             raise error.SpannerError("Condition must be bound before usage")
         return self._params()
@@ -100,10 +100,10 @@ class Condition(abc.ABC):
     def types(self) -> Dict[str, type_pb2.Type]:
         """Returns parameter types to be used in the SQL query.
 
-    Returns:
-      Dictionary mapping from parameter name to the type of the value that
-      should be substituted for that parameter in the SQL query
-    """
+        Returns:
+          Dictionary mapping from parameter name to the type of the value that
+          should be substituted for that parameter in the SQL query
+        """
         if not self.model_class:
             raise error.SpannerError("Condition must be bound before usage")
         return self._types()
@@ -628,58 +628,58 @@ def columns_equal(
 ) -> ColumnsEqualCondition:
     """Condition where the specified columns are equal.
 
-  Used in 'includes' to fetch related models where the foreign key matches the
-  local value.
+    Used in 'includes' to fetch related models where the foreign key matches the
+    local value.
 
-  Args:
-    origin_column: Name of the column on the origin model to compare from
-    dest_model_class: Type of model that is being compared to
-    dest_column: Name of column on the destination model being compared to
+    Args:
+      origin_column: Name of the column on the origin model to compare from
+      dest_model_class: Type of model that is being compared to
+      dest_column: Name of column on the destination model being compared to
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ColumnsEqualCondition(origin_column, dest_model_class, dest_column)
 
 
 def equal_to(column: Union[field.Field, str], value: Any) -> EqualityCondition:
     """Condition where the specified column is equal to the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return EqualityCondition(column, value)
 
 
 def force_index(forced_index: Union[index.Index, str]) -> ForceIndexCondition:
     """Condition to force the query to use the given index.
 
-  Args:
-    forced_index: Name of the index on the origin model or the Index on the
-      origin model class to use
+    Args:
+      forced_index: Name of the index on the origin model or the Index on the
+        origin model class to use
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ForceIndexCondition(forced_index)
 
 
 def greater_than(column: Union[field.Field, str], value: Any) -> ComparisonCondition:
     """Condition where the specified column is greater than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
 
     return ComparisonCondition(">", column, value)
 
@@ -689,14 +689,14 @@ def greater_than_or_equal_to(
 ) -> ComparisonCondition:
     """Condition where the specified column is not less than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ComparisonCondition(">=", column, value)
 
 
@@ -705,19 +705,19 @@ def includes(
 ) -> IncludesCondition:
     """Condition where the objects associated with a relationship are retrieved.
 
-  Note that the query formed by this call is not a JOIN, but instead a
-  subquery on the table on the other side of the relationship. To narrow
-  down the objects retrieved in the subquery, conditions that apply to that
-  subquery may be included, but not all conditions may apply
+    Note that the query formed by this call is not a JOIN, but instead a
+    subquery on the table on the other side of the relationship. To narrow
+    down the objects retrieved in the subquery, conditions that apply to that
+    subquery may be included, but not all conditions may apply
 
-  Args:
-    relation: Name of the relationship on the origin model or the Relationship
-      on the origin model class used to retrievec associated objects
-    conditions: Conditions to apply on the subquery
+    Args:
+      relation: Name of the relationship on the origin model or the Relationship
+        on the origin model class used to retrievec associated objects
+      conditions: Conditions to apply on the subquery
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return IncludesCondition(relation, conditions)
 
 
@@ -726,29 +726,29 @@ def in_list(
 ) -> ListComparisonCondition:
     """Condition where the specified column matches a value from the given list.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    values: A list of values. Any row for which the specified column matches a
-      value in this list will be included in the result set.
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      values: A list of values. Any row for which the specified column matches a
+        value in this list will be included in the result set.
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ListComparisonCondition("IN", column, values)
 
 
 def less_than(column: Union[field.Field, str], value: Any) -> ComparisonCondition:
     """Condition where the specified column is less than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ComparisonCondition("<", column, value)
 
 
@@ -757,42 +757,42 @@ def less_than_or_equal_to(
 ) -> ComparisonCondition:
     """Condition where the specified column is not greater than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ComparisonCondition("<=", column, value)
 
 
 def limit(value: int, offset: int = 0) -> LimitCondition:
     """Condition that specifies LIMIT and OFFSET of the query.
 
-  Args:
-    value: Ceiling on number of results in the result set
-    offset: The index of the first item in the results to include in the result
-      set
+    Args:
+      value: Ceiling on number of results in the result set
+      offset: The index of the first item in the results to include in the result
+        set
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return LimitCondition(value, offset=offset)
 
 
 def not_equal_to(column: Union[field.Field, str], value: Any) -> InequalityCondition:
     """Condition where the specified column is not equal to the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return InequalityCondition(column, value)
 
 
@@ -801,14 +801,14 @@ def not_greater_than(
 ) -> ComparisonCondition:
     """Condition where the specified column is not greater than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return less_than_or_equal_to(column, value)
 
 
@@ -817,70 +817,70 @@ def not_in_list(
 ) -> ListComparisonCondition:
     """Condition where the specified column does not matche a value from the list.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    values: A list of values. Any row for which the specified column does not
-      match any values in this list will be included in the result set.
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      values: A list of values. Any row for which the specified column does not
+        match any values in this list will be included in the result set.
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return ListComparisonCondition("NOT IN", column, values)
 
 
 def not_less_than(column: Union[field.Field, str], value: Any) -> ComparisonCondition:
     """Condition where the specified column is not less than the given value.
 
-  Args:
-    column: Name of the column on the origin model or the Field on the origin
-      model class to compare from
-    value: The value to compare against
+    Args:
+      column: Name of the column on the origin model or the Field on the origin
+        model class to compare from
+      value: The value to compare against
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return greater_than_or_equal_to(column, value)
 
 
 def or_(*condition_lists: List[Condition]) -> OrCondition:
     """Condition allows more complicated OR queries.
 
-  Args:
-    *condition_lists: Each value is a list of conditions that are combined using
-      AND (which is also the default when using Model.where) All the values will
-      then be combined using OR.
+    Args:
+      *condition_lists: Each value is a list of conditions that are combined using
+        AND (which is also the default when using Model.where) All the values will
+        then be combined using OR.
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return OrCondition(*condition_lists)
 
 
 def order_by(*orderings: Tuple[Union[field.Field, str], OrderType]) -> OrderByCondition:
     """Condition that specifies the ordering of the result set.
 
-  Args:
-    *orderings: A list of tuples. The first item in each tuple is the name of
-      the column on the model or the Field on the model class which is being
-      ordered. The second item is the OrderType to use (which is either
-      ascending or descending). The index in the list indicates the position of
-      that ordering in the resulting ORDER BY statement
+    Args:
+      *orderings: A list of tuples. The first item in each tuple is the name of
+        the column on the model or the Field on the model class which is being
+        ordered. The second item is the OrderType to use (which is either
+        ascending or descending). The index in the list indicates the position of
+        that ordering in the resulting ORDER BY statement
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return OrderByCondition(*orderings)
 
 
 def select_columns(columns: List[Union[field.Field, str]]) -> SelectColumnsCondition:
     """Condition to limit which columns should be queried. Default is to query all columns.
-    All the omitted fields will be set to None.
+      All the omitted fields will be set to None.
 
-  Args:
-    columns: Column names to query
+    Args:
+      columns: Column names to query
 
-  Returns:
-    A Condition subclass that will be used in the query
-  """
+    Returns:
+      A Condition subclass that will be used in the query
+    """
     return SelectColumnsCondition(columns)

--- a/spanner_orm/decorator.py
+++ b/spanner_orm/decorator.py
@@ -24,32 +24,32 @@ T = TypeVar("T")
 def transactional_read(func: Callable[..., T]) -> Callable[..., T]:
     """Injects a read-only transaction as keyword argument to given function.
 
-    For example:
+      For example:
 
-    @transactional_read
-    def get_book(book_id, transaction=None):
-      return Book(book_id)
+      @transactional_read
+      def get_book(book_id, transaction=None):
+        return Book(book_id)
 
-    Client would then call this by skipping the 'transaction' argument:
-    book_reader.get_book(123)
+      Client would then call this by skipping the 'transaction' argument:
+      book_reader.get_book(123)
 
-    To call a decorated function if you already have a transaction:
+      To call a decorated function if you already have a transaction:
 
-    @transactional_read
-    def list_books(book_ids, transaction=None):
-      for book_id in book_ids:
-        get_book(book_id, transaction=transaction)
+      @transactional_read
+      def list_books(book_ids, transaction=None):
+        for book_id in book_ids:
+          get_book(book_id, transaction=transaction)
 
-    list_books method would call get_book method using same transaction
+      list_books method would call get_book method using same transaction
 
-  Args:
-    func: Callable which will be called with read-only transaction and original
-      arguments. Decorated `func` can also be passed an optional 'transaction'
-      kwarg to use a given transaction, instead of creating a new one.
+    Args:
+      func: Callable which will be called with read-only transaction and original
+        arguments. Decorated `func` can also be passed an optional 'transaction'
+        kwarg to use a given transaction, instead of creating a new one.
 
-  Returns:
-    decorated function
-  """
+    Returns:
+      decorated function
+    """
     api_method_lambda = lambda: api.spanner_api().run_read_only
     return _transactional(api_method_lambda, func)
 
@@ -57,32 +57,32 @@ def transactional_read(func: Callable[..., T]) -> Callable[..., T]:
 def transactional_write(func: Callable[..., T]) -> Callable[..., T]:
     """Injects a write transaction object as first argument to given function.
 
-    For example:
+      For example:
 
-    @transactional_write
-    def save_book(book_id, transaction=None):
-      ...
+      @transactional_write
+      def save_book(book_id, transaction=None):
+        ...
 
-    Client would then call this by skipping the 'transaction' argument:
-    book_reader.save_book(123)
+      Client would then call this by skipping the 'transaction' argument:
+      book_reader.save_book(123)
 
-    To call a decorated function if you already have a transaction:
+      To call a decorated function if you already have a transaction:
 
-    @transactional_write
-    def save_books(book_ids, transaction=None):
-      for book_id in book_ids:
-        save_book(book_id, transaction=transaction)
+      @transactional_write
+      def save_books(book_ids, transaction=None):
+        for book_id in book_ids:
+          save_book(book_id, transaction=transaction)
 
-    save_books method would call save_book method using same transaction
+      save_books method would call save_book method using same transaction
 
-  Args:
-    func: Callable which will be called with write transaction and original
-      arguments. Decorated `func` can also be passed an optional 'transaction'
-      kwarg to use a given transaction, instead of creating a new one.
+    Args:
+      func: Callable which will be called with write transaction and original
+        arguments. Decorated `func` can also be passed an optional 'transaction'
+        kwarg to use a given transaction, instead of creating a new one.
 
-  Returns:
-    decorated function
-  """
+    Returns:
+      decorated function
+    """
     api_method_lambda = lambda: api.spanner_api().run_write
     return _transactional(api_method_lambda, func)
 

--- a/spanner_orm/index.py
+++ b/spanner_orm/index.py
@@ -35,18 +35,18 @@ class Index(object):
         column_ordering: Union[Dict[str, bool], bool] = None,
     ):
         """
-    Represents an index on the table
+        Represents an index on the table
 
-    :param columns: List of columns in the index
-    :param parent:
-    :param null_filtered: Should null values be filtered?
-    :param unique: Enforce unique constraint?
-    :param storing_columns: Additional columns to store with this index. This can help performance if fields are
-      accessed together
-    :param name: Name of the index (this may be used to customize default index name)
-    :param column_ordering: Map of column names to bool (True for ASC, and False for DESC) indicating order for the
-      field (defaults to ASC). For single column indexes, this can be a single bool value as well.
-    """
+        :param columns: List of columns in the index
+        :param parent:
+        :param null_filtered: Should null values be filtered?
+        :param unique: Enforce unique constraint?
+        :param storing_columns: Additional columns to store with this index. This can help performance if fields are
+          accessed together
+        :param name: Name of the index (this may be used to customize default index name)
+        :param column_ordering: Map of column names to bool (True for ASC, and False for DESC) indicating order for the
+          field (defaults to ASC). For single column indexes, this can be a single bool value as well.
+        """
         if not columns:
             raise error.ValidationError("An index must have at least one column")
         if isinstance(column_ordering, bool):
@@ -95,8 +95,8 @@ class Index(object):
     @property
     def column_ordering(self) -> Dict[str, bool]:
         """
-    Map of column name to order (True for ascending, False for descending)
-    """
+        Map of column name to order (True for ascending, False for descending)
+        """
         return self._column_ordering
 
     @property

--- a/spanner_orm/metadata.py
+++ b/spanner_orm/metadata.py
@@ -62,12 +62,12 @@ class ModelMetadata(object):
     def finalize(self, reregister_model: bool = False) -> None:
         """Finish generating metadata state.
 
-    Some metadata depends on having all configuration data set before it can
-    be calculated--the primary index, for example, needs all fields to be added
-    before it can be calculated. This method is called to indicate that all
-    relevant state has been added and the calculation of the final data should
-    now happen.
-    """
+        Some metadata depends on having all configuration data set before it can
+        be calculated--the primary index, for example, needs all fields to be added
+        before it can be calculated. This method is called to indicate that all
+        relevant state has been added and the calculation of the final data should
+        now happen.
+        """
         if self._finalized:
             raise error.SpannerError("Metadata was already finalized")
         sorted_fields = list(sorted(self.fields.values(), key=lambda f: f.position))

--- a/spanner_orm/model.py
+++ b/spanner_orm/model.py
@@ -133,10 +133,10 @@ CallableReturn = TypeVar("CallableReturn")
 class ModelApi(metaclass=ModelMetaclass):
     """Implements class-level Spanner queries on top of ModelMetaclass.
 
-  Note: all methods in this class should only be called on subclasses of Model
-  that have associated tables. Violating this will cause an exception to be
-  raised.
-  """
+    Note: all methods in this class should only be called on subclasses of Model
+    that have associated tables. Violating this will cause an exception to be
+    raised.
+    """
 
     @classmethod
     def spanner_api(cls) -> api.SpannerApi:
@@ -151,17 +151,17 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> List["ModelObject"]:
         """Returns all objects of this type stored in Spanner.
 
-    Note: this method should only be called on subclasses of Model that have
-    a table associated with it. Violating this will cause an exception to be
-    raised.
+        Note: this method should only be called on subclasses of Model that have
+        a table associated with it. Violating this will cause an exception to be
+        raised.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
 
-    Returns:
-      A list of models, one per row in the associated Spanner table
-    """
+        Returns:
+          A list of models, one per row in the associated Spanner table
+        """
         args = [cls.table, cls.columns, spanner.KeySet(all_=True)]
         results = cls._execute_read(table_apis.find, transaction, args)
         return cls._results_to_models(results)
@@ -174,16 +174,16 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> int:
         """Returns the number of objects in Spanner that match the given conditions.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      *conditions: Instances of subclasses of Condition that help specify which
-        rows should be included in the count. The includes condition is not
-        allowed here
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          *conditions: Instances of subclasses of Condition that help specify which
+            rows should be included in the count. The includes condition is not
+            allowed here
 
-    Returns:
-      The integer result of the COUNT query
-    """
+        Returns:
+          The integer result of the COUNT query
+        """
         builder = query.CountQuery(cls, conditions)
         args = [builder.sql(), builder.parameters(), builder.types()]
         results = cls._execute_read(table_apis.sql_query, transaction, args)
@@ -197,19 +197,19 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> int:
         """Returns the number of objects in Spanner that match the given conditions.
 
-    Convenience method that generates equality conditions based on the keyword
-    arguments.
+        Convenience method that generates equality conditions based on the keyword
+        arguments.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      **constraints: Each key/value pair is turned into an equality condition:
-        the key is used as the column in the condition and the value is used as
-        the value to compare the column against in the query.
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          **constraints: Each key/value pair is turned into an equality condition:
+            the key is used as the column in the condition and the value is used as
+            the value to compare the column against in the query.
 
-    Returns:
-      The integer result of the COUNT query
-    """
+        Returns:
+          The integer result of the COUNT query
+        """
         conditions = []
         for column, value in constraints.items():
             if isinstance(value, list):
@@ -224,16 +224,16 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> Optional["ModelObject"]:
         """Retrieves an object from Spanner based on the provided key.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      **keys: The keys provided are the complete set of primary keys for this
-        table and the corresponding values make up the unique identifier of the
-        object being retrieved
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          **keys: The keys provided are the complete set of primary keys for this
+            table and the corresponding values make up the unique identifier of the
+            object being retrieved
 
-    Returns:
-      The requested object or None if no such object exists
-    """
+        Returns:
+          The requested object or None if no such object exists
+        """
         resources = cls.find_multi(transaction, [keys])
         return resources[0] if resources else None
 
@@ -245,17 +245,17 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> List["ModelObject"]:
         """Retrieves objects from Spanner based on the provided keys.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      keys: An iterable of dictionaries, each dictionary representing the set of
-        primary key values necessary to uniquely identify an object in this
-        table.
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          keys: An iterable of dictionaries, each dictionary representing the set of
+            primary key values necessary to uniquely identify an object in this
+            table.
 
-    Returns:
-      A list containing all requested objects that exist in the table (can be
-      an empty list)
-    """
+        Returns:
+          A list containing all requested objects that exist in the table (can be
+          an empty list)
+        """
         key_values = []
         for key in keys:
             key_values.append([key[column] for column in cls.primary_keys])
@@ -273,16 +273,16 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> List["ModelObject"]:
         """Retrieves objects from Spanner based on the provided conditions.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      *conditions: Instances of subclasses of Condition that help specify which
-        objects should be retrieved
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          *conditions: Instances of subclasses of Condition that help specify which
+            objects should be retrieved
 
-    Returns:
-      A list containing all requested objects that exist in the table (can be
-      an empty list)
-    """
+        Returns:
+          A list containing all requested objects that exist in the table (can be
+          an empty list)
+        """
         builder = query.SelectQuery(cls, conditions)
         args = [builder.sql(), builder.parameters(), builder.types()]
         results = cls._execute_read(table_apis.sql_query, transaction, args)
@@ -296,17 +296,17 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> List["ModelObject"]:
         """Retrieves objects from Spanner based on the provided constraints.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      **constraints: Each key/value pair is turned into an equality condition:
-        the key is used as the column in the condition and the value is used as
-        the value to compare the column against in the query.
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          **constraints: Each key/value pair is turned into an equality condition:
+            the key is used as the column in the condition and the value is used as
+            the value to compare the column against in the query.
 
-    Returns:
-      A list containing all requested objects that exist in the table (can be
-      an empty list)
-    """
+        Returns:
+          A list containing all requested objects that exist in the table (can be
+          an empty list)
+        """
         conditions = []
         for column, value in constraints.items():
             if isinstance(value, list):
@@ -343,15 +343,15 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> None:
         """Creates a row in Spanner based on the provided data.
 
-    Note: may throw an exception if bad values are provided.
+        Note: may throw an exception if bad values are provided.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      **kwargs: The keys are columns on the table and the values are the values
-        each column in the table should be set to. None and keys not present
-        indicate the corresponding column value should be NULL.
-    """
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          **kwargs: The keys are columns on the table and the values are the values
+            each column in the table should be set to. None and keys not present
+            indicate the corresponding column value should be NULL.
+        """
         cls._execute_write(table_apis.insert, transaction, [kwargs])
 
     @classmethod
@@ -370,11 +370,11 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> None:
         """Deletes rows from Spanner based on the provided models' primary keys.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      models: A list of models to be deleted from Spanner.
-    """
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          models: A list of models to be deleted from Spanner.
+        """
         key_list = []
         for model in models:
             key_list.append([getattr(model, column) for column in cls.primary_keys])
@@ -396,18 +396,18 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> None:
         """Writes rows to Spanner based on the provided model data.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      models: A list of models to be written to Spanner. If the _persisted flag
-        is set, by default we try to issue an UPDATE with values set for all
-        columns in the table. Otherwise, we try to issue an INSERT for all
-        columns in the table. If we try to INSERTa row that already exists (or
-        update one that is missing), an exception will be thrown.
-      force_write: If true, we use UPSERT instead of UPDATE/INSERT, so no
-        exceptions are thrown based on the presence or absence of data in
-        Spanner
-    """
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          models: A list of models to be written to Spanner. If the _persisted flag
+            is set, by default we try to issue an UPDATE with values set for all
+            columns in the table. Otherwise, we try to issue an INSERT for all
+            columns in the table. If we try to INSERTa row that already exists (or
+            update one that is missing), an exception will be thrown.
+          force_write: If true, we use UPSERT instead of UPDATE/INSERT, so no
+            exceptions are thrown based on the presence or absence of data in
+            Spanner
+        """
         work = collections.defaultdict(list)
         for model in models:
             value = {column: getattr(model, column) for column in cls.columns}
@@ -430,14 +430,14 @@ class ModelApi(metaclass=ModelMetaclass):
     ) -> None:
         """Updates a row in Spanner based on the provided data.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-      **kwargs: The keys are columns on the table and the values are the values
-        each column in the table should be set to. None indicates indicate the
-        corresponding column value should be NULL and not present keys indicate
-        the corresponding column value should not be changed.
-    """
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+          **kwargs: The keys are columns on the table and the values are the values
+            each column in the table should be set to. None indicates indicate the
+            corresponding column value should be NULL and not present keys indicate
+            the corresponding column value should not be changed.
+        """
         cls._execute_write(table_apis.update, transaction, [kwargs])
 
     @classmethod
@@ -544,17 +544,17 @@ class Model(ModelApi):
     def values(self) -> Dict[str, Any]:
         """Gets all attributes.
 
-    Returns:
-      Dictionary mapping from attribute name to value.
-    """
+        Returns:
+          Dictionary mapping from attribute name to value.
+        """
         return {key: getattr(self, key) for key in self._columns}
 
     def changes(self) -> Dict[str, Any]:
         """Gets all attributes that have been updated since object creation.
 
-    Returns:
-      Dictionary mapping from changed attribute name to new value.
-    """
+        Returns:
+          Dictionary mapping from changed attribute name to new value.
+        """
         values = self.values
         return {
             key: values[key]
@@ -565,10 +565,10 @@ class Model(ModelApi):
     def delete(self, transaction: spanner_transaction.Transaction = None) -> None:
         """Deletes this object from the Spanner database.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
-    """
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
+        """
         key = [getattr(self, column) for column in self._primary_keys]
         keyset = spanner.KeySet([key])
 
@@ -582,11 +582,11 @@ class Model(ModelApi):
     def pkey(self) -> Dict[str, Any]:
         """Gets the primary key of this object.
 
-    Returns:
-      Dictionary mapping from primary key attribute name to values. Note: this
-      dictionary can be used with Model.find to return the updated version of
-      this object from Spanner.
-    """
+        Returns:
+          Dictionary mapping from primary key attribute name to values. Note: this
+          dictionary can be used with Model.find to return the updated version of
+          this object from Spanner.
+        """
         return {key: self.values[key] for key in self._primary_keys}
 
     def reload(
@@ -594,15 +594,15 @@ class Model(ModelApi):
     ) -> Optional["Model"]:
         """Refreshes this object with information from Spanner.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
 
-    Returns:
-      This object updated with the appropriate values if information was found
-      in Spanner, or None if no information was found (object was deleted or
-      never was persisted)
-    """
+        Returns:
+          This object updated with the appropriate values if information was found
+          in Spanner, or None if no information was found (object was deleted or
+          never was persisted)
+        """
         updated_object = self._metaclass.find(transaction, **self.pkey())
         if updated_object is None:
             return None
@@ -621,17 +621,17 @@ class Model(ModelApi):
     def save(self, transaction: spanner_transaction.Transaction = None) -> "Model":
         """Persists this object to Spanner.
 
-    Note: if the _persisted flag doesn't match whether this object is actually
-    stored in Spanner, an exception may be thrown due to using the wrong
-    API.
+        Note: if the _persisted flag doesn't match whether this object is actually
+        stored in Spanner, an exception may be thrown due to using the wrong
+        API.
 
-    Args:
-      transaction: The existing transaction to use, or None to start a new
-        transaction
+        Args:
+          transaction: The existing transaction to use, or None to start a new
+            transaction
 
-    Returns:
-      The current object
-    """
+        Returns:
+          The current object
+        """
         if self._persisted:
             changed_values = self.changes()
             if changed_values:

--- a/spanner_orm/query.py
+++ b/spanner_orm/query.py
@@ -179,7 +179,9 @@ class SelectQuery(SpannerQuery):
         selects = self._segments(condition.Segment.SELECT)
         if selects:
             if len(selects) != 1:
-                raise error.SpannerError("Only one select column condition may be specified")
+                raise error.SpannerError(
+                    "Only one select column condition may be specified"
+                )
             select_columns = cast(condition.SelectColumnsCondition, selects[0])
             self._columns = select_columns.columns
 

--- a/spanner_orm/relationship.py
+++ b/spanner_orm/relationship.py
@@ -41,17 +41,17 @@ class Relationship(object):
     ):
         """Creates a ModelRelationship.
 
-    Args:
-      destination_handle: Destination model class or fully qualified class name
-        of the destination model
-      constraints: Dictionary where the keys are names of columns from the
-        origin model and the value for a key is the name of the column in the
-        destination model that the key should be equal to in order for there to
-        be a relationship from an origin model to the destination
-      is_parent: True if the destination is a parent table of the origin
-      single: True if the destination should be treated as a single object
-        instead of a list of objects
-    """
+        Args:
+          destination_handle: Destination model class or fully qualified class name
+            of the destination model
+          constraints: Dictionary where the keys are names of columns from the
+            origin model and the value for a key is the name of the column in the
+            destination model that the key should be equal to in order for there to
+            be a relationship from an origin model to the destination
+          is_parent: True if the destination is a parent table of the origin
+          single: True if the destination should be treated as a single object
+            instead of a list of objects
+        """
         self.origin = None
         self.name = None
         self._destination_handle = destination_handle

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -33,19 +33,19 @@ def find(
 ) -> List[Iterable[Any]]:
     """Retrieves rows from the given table based on the provided KeySet.
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    table_name: The Spanner table being queried
-    columns: Which columns to retrieve from the Spanner table
-    keyset: Contains a list of primary keys that indicates which rows to
-      retrieve from the Spanner table
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      table_name: The Spanner table being queried
+      columns: Which columns to retrieve from the Spanner table
+      keyset: Contains a list of primary keys that indicates which rows to
+        retrieve from the Spanner table
 
-  Returns:
-    A list of lists. Each sublist is the set of `columns` requested from
-    a row in the Spanner table whose primary key matches one of the
-    primary keys in the `keyset`. The order of the values in the sublist
-    matches the order of the columns from the `columns` parameter.
-  """
+    Returns:
+      A list of lists. Each sublist is the set of `columns` requested from
+      a row in the Spanner table whose primary key matches one of the
+      primary keys in the `keyset`. The order of the values in the sublist
+      matches the order of the columns from the `columns` parameter.
+    """
     _logger.debug("Find table=%s columns=%s keys=%s", table_name, columns, keyset.keys)
     stream_results = transaction.read(table=table_name, columns=columns, keyset=keyset)
     return list(stream_results)
@@ -60,23 +60,23 @@ def sql_query(
 ) -> List[Iterable[Any]]:
     """Executes a given SQL query against the Spanner database.
 
-  This isn't technically read-only, but it's necessary to implement the read-
-  only features of the ORM
+    This isn't technically read-only, but it's necessary to implement the read-
+    only features of the ORM
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    query: The SQL query to run
-    parameters: A mapping from the names of the parameters used in the SQL query
-      to the value to be substituted in for that parameter
-    parameter_types: A mapping from the names of the parameters used in the SQL
-      query to the type of the value being substituted in for that parameter
-    kwargs: Additional keyword args to pass to `transaction.execute_sql`
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      query: The SQL query to run
+      parameters: A mapping from the names of the parameters used in the SQL query
+        to the value to be substituted in for that parameter
+      parameter_types: A mapping from the names of the parameters used in the SQL
+        query to the type of the value being substituted in for that parameter
+      kwargs: Additional keyword args to pass to `transaction.execute_sql`
 
-  Returns:
-    A list of lists. Each sublist is a result row from the SQL query. For
-    SELECT queries, the order of values in the sublist matches the order
-    of the columns requested from the SELECT clause of the query.
-  """
+    Returns:
+      A list of lists. Each sublist is a result row from the SQL query. For
+      SELECT queries, the order of values in the sublist matches the order
+      of the columns requested from the SELECT clause of the query.
+    """
     _logger.debug("Executing SQL:\n%s\n%s\n%s", query, parameters, parameter_types)
     stream_results = transaction.execute_sql(
         query, params=parameters, param_types=parameter_types, **kwargs
@@ -91,12 +91,12 @@ def delete(
 ) -> None:
     """Deletes rows from the given table based on the provided KeySet.
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    table_name: The Spanner table being modified
-    keyset: Contains a list of primary keys that indicates which rows to delete
-      from the Spanner table
-  """
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      table_name: The Spanner table being modified
+      keyset: Contains a list of primary keys that indicates which rows to delete
+        from the Spanner table
+    """
 
     _logger.debug("Delete table=%s keys=%s", table_name, keyset.keys)
     transaction.delete(table=table_name, keyset=keyset)
@@ -110,18 +110,18 @@ def insert(
 ) -> None:
     """Adds rows to the given table based on the provided values.
 
-  All non-nullable columns must be specified. Note that if a row is specified
-  for which the primary key already exists in the table, an exception will
-  be thrown and the insert will be aborted.
+    All non-nullable columns must be specified. Note that if a row is specified
+    for which the primary key already exists in the table, an exception will
+    be thrown and the insert will be aborted.
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    table_name: The Spanner table being modified
-    columns: Which columns to write on the Spanner table
-    values: A list of rows to write to the table. The order of the values in
-      each sublist must match the order of the columns specified in the
-      `columns` parameter.
-  """
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      table_name: The Spanner table being modified
+      columns: Which columns to write on the Spanner table
+      values: A list of rows to write to the table. The order of the values in
+        each sublist must match the order of the columns specified in the
+        `columns` parameter.
+    """
     _logger.debug("Insert table=%s columns=%s values=%s", table_name, columns, values)
     transaction.insert(table=table_name, columns=columns, values=values)
 
@@ -134,18 +134,18 @@ def update(
 ) -> None:
     """Updates rows in the given table based on the provided values.
 
-  Note that if a row is specified for which the primary key does not
-  exist in the table, an exception will be thrown and the update
-  will be aborted.
+    Note that if a row is specified for which the primary key does not
+    exist in the table, an exception will be thrown and the update
+    will be aborted.
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    table_name: The Spanner table being modified
-    columns: Which columns to write on the Spanner table
-    values: A list of rows to write to the table. The order of the values in
-      each sublist must match the order of the columns specified in the
-      `columns` parameter.
-  """
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      table_name: The Spanner table being modified
+      columns: Which columns to write on the Spanner table
+      values: A list of rows to write to the table. The order of the values in
+        each sublist must match the order of the columns specified in the
+        `columns` parameter.
+    """
     _logger.debug("Update table=%s columns=%s values=%s", table_name, columns, values)
     transaction.update(table=table_name, columns=columns, values=values)
 
@@ -158,17 +158,17 @@ def upsert(
 ) -> None:
     """Inserts or updates rows in the given table based on the provided values.
 
-  All non-nullable columns must be specified, similarly to the insert method.
-  The presence or absence of data in the table will not cause an exception
-  to be thrown, unlike insert or update.
+    All non-nullable columns must be specified, similarly to the insert method.
+    The presence or absence of data in the table will not cause an exception
+    to be thrown, unlike insert or update.
 
-  Args:
-    transaction: The Spanner transaction to execute the request on
-    table_name: The Spanner table being modified
-    columns: Which columns to write on the Spanner table
-    values: A list of rows to write to the table. The order of the values in
-      each sublist must match the order of the columns specified in the
-      `columns` parameter.
-  """
+    Args:
+      transaction: The Spanner transaction to execute the request on
+      table_name: The Spanner table being modified
+      columns: Which columns to write on the Spanner table
+      values: A list of rows to write to the table. The order of the values in
+        each sublist must match the order of the columns specified in the
+        `columns` parameter.
+    """
     _logger.debug("Upsert table=%s columns=%s values=%s", table_name, columns, values)
     transaction.insert_or_update(table=table_name, columns=columns, values=values)

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -135,7 +135,7 @@ class ModelTest(parameterized.TestCase):
             _ = test_model.parent
 
     def test_interleaved(self):
-        self.assertEqual(models.ChildTestModel.interleaved, models.SmallTestModel)
+        self.assertEqual(models.ChildTestModel.interleaved, models.SmallTestParentModel)
 
     @mock.patch("spanner_orm.model.ModelApi.find")
     def test_reload(self, find):

--- a/spanner_orm/tests/model_test.py
+++ b/spanner_orm/tests/model_test.py
@@ -32,7 +32,11 @@ class ModelTest(parameterized.TestCase):
         test_model.value_2 = "value_2"
         self.assertEqual(
             test_model.values,
-            {"key": "key", "value_1": "value_1", "value_2": "value_2",},
+            {
+                "key": "key",
+                "value_1": "value_1",
+                "value_2": "value_2",
+            },
         )
 
     def test_set_error_on_primary_key(self):

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -30,11 +30,25 @@ class SmallTestModel(model.Model):
     index_1 = index.Index(["value_1"])
 
 
+class SmallTestParentModel(model.Model):
+    """Model class used for testing."""
+
+    __table__ = "SmallTestParentModel"
+    key = field.Field(field.String, primary_key=True)
+    value_1 = field.Field(field.String)
+    value_2 = field.Field(field.String, nullable=True)
+    index_1 = index.Index(["value_1"])
+
+    children = relationship.Relationship(
+        "spanner_orm.tests.models.ChildTestModel", {"key": "key"}
+    )
+
+
 class ChildTestModel(model.Model):
     """Model class for testing interleaved tables."""
 
     __table__ = "ChildTestModel"
-    __interleaved__ = "SmallTestModel"
+    __interleaved__ = "SmallTestParentModel"
 
     key = field.Field(field.String, primary_key=True)
     child_key = field.Field(field.String, primary_key=True)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -129,7 +129,9 @@ class QueryTest(parameterized.TestCase):
         self.assertNotRegex(select_query.sql(), "ORDER BY")
 
     def test_query_select_fields(self):
-        select_query = self.select(condition.select_columns([models.UnittestModel.int_]))
+        select_query = self.select(
+            condition.select_columns([models.UnittestModel.int_])
+        )
 
         self.assertEqual(select_query.sql(), "SELECT table.int_ FROM table")
         self.assertEmpty(select_query.parameters())

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -245,7 +245,6 @@ class UpdateTest(unittest.TestCase):
         new_model = models.RelationshipTestModel
         test_update = update.CreateTable(new_model)
         test_update.validate()
-        print(test_update.ddl())
 
         test_model_ddl = (
             "CREATE TABLE RelationshipTestModel ("
@@ -288,7 +287,6 @@ class UpdateTest(unittest.TestCase):
             },
         )
         test_update.validate()
-        print(test_update.ddl())
 
         test_model_ddl = (
             "CREATE TABLE RelationshipTestModel ("

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -16,7 +16,7 @@ import logging
 import unittest
 from unittest import mock
 
-from spanner_orm import error
+from spanner_orm import error, relationship
 from spanner_orm import field
 from spanner_orm.admin import update
 from spanner_orm.index import Index
@@ -120,10 +120,114 @@ class UpdateTest(unittest.TestCase):
         self.assertEqual(test_update.ddl(), test_model_ddl)
 
     @mock.patch("spanner_orm.admin.metadata.SpannerMetadata.model")
+    def test_create_table_no_model(self, get_model):
+        get_model.return_value = None
+        test_update = update.CreateTable(
+            table_name="table",
+            primary_keys=["int_", "float_", "string"],
+            fields={
+                "int_": field.Field(field.Integer, primary_key=True, name="int_"),
+                "int_2": field.Field(field.Integer, nullable=True, name="int_2"),
+                "float_": field.Field(field.Float, primary_key=True, name="float_"),
+                "float_2": field.Field(field.Float, nullable=True, name="float_2"),
+                "string": field.Field(field.String, primary_key=True, name="string"),
+                "string_2": field.Field(field.String, nullable=True, name="string_2"),
+                "string_3": field.Field(
+                    field.String, nullable=True, size=10, name="string_3"
+                ),
+                "timestamp": field.Field(field.Timestamp, name="timestamp"),
+                "timestamp_2": field.Field(
+                    field.Timestamp,
+                    nullable=True,
+                    allow_commit_timestamp=True,
+                    name="timestamp_2",
+                ),
+                "date": field.Field(field.Date, nullable=True, name="date"),
+                "bool_array": field.Field(
+                    field.BoolArray, nullable=True, name="bool_array"
+                ),
+                "int_array": field.Field(
+                    field.IntegerArray, nullable=True, name="int_array"
+                ),
+                "float_array": field.Field(
+                    field.FloatArray, nullable=True, name="float_array"
+                ),
+                "date_array": field.Field(
+                    field.DateArray, nullable=True, name="date_array"
+                ),
+                "string_array": field.Field(
+                    field.StringArray, nullable=True, name="string_array"
+                ),
+                "string_array_2": field.Field(
+                    field.StringArray, nullable=True, size=50, name="string_array_2"
+                ),
+            },
+        )
+        test_update.validate()
+
+        test_model_ddl = (
+            "CREATE TABLE table (int_ INT64 NOT NULL, int_2 INT64,"
+            " float_ FLOAT64 NOT NULL, float_2 FLOAT64,"
+            " string STRING(MAX) NOT NULL, string_2 STRING(MAX),"
+            " string_3 STRING(10),"
+            " timestamp TIMESTAMP NOT NULL,"
+            " timestamp_2 TIMESTAMP OPTIONS (allow_commit_timestamp=true),"
+            " date DATE,"
+            " bool_array ARRAY<BOOL>,"
+            " int_array ARRAY<INT64>,"
+            " float_array ARRAY<FLOAT64>,"
+            " date_array ARRAY<DATE>,"
+            " string_array ARRAY<STRING(MAX)>,"
+            " string_array_2 ARRAY<STRING(50)>) PRIMARY KEY (int_, float_, string)"
+        )
+        self.assertEqual(test_update.ddl(), test_model_ddl)
+
+    @mock.patch("spanner_orm.admin.metadata.SpannerMetadata.model")
     def test_create_table_interleaved(self, get_model):
         get_model.return_value = None
         new_model = models.ChildTestModel
         test_update = update.CreateTable(new_model)
+        test_update.validate()
+
+        test_model_ddl = (
+            "CREATE TABLE ChildTestModel ("
+            "key STRING(MAX) NOT NULL, "
+            "child_key STRING(MAX) NOT NULL) "
+            "PRIMARY KEY (key, child_key), "
+            "INTERLEAVE IN PARENT SmallTestParentModel ON DELETE CASCADE"
+        )
+        self.assertEqual(test_update.ddl(), test_model_ddl)
+
+    @mock.patch("spanner_orm.admin.metadata.SpannerMetadata.model")
+    def test_create_table_interleaved_parent(self, get_model):
+        get_model.return_value = None
+        new_model = models.SmallTestParentModel
+        test_update = update.CreateTable(new_model)
+        test_update.validate()
+
+        test_model_ddl = (
+            "CREATE TABLE SmallTestParentModel ("
+            "key STRING(MAX) NOT NULL, "
+            "value_1 STRING(MAX) NOT NULL, "
+            "value_2 STRING(MAX)) "
+            "PRIMARY KEY (key)"
+        )
+        self.assertEqual(test_update.ddl(), test_model_ddl)
+
+    @mock.patch("spanner_orm.admin.metadata.SpannerMetadata.model")
+    def test_create_table_interleaved_no_model(self, get_model):
+        get_model.return_value = None
+        test_update = update.CreateTable(
+            table_name="ChildTestModel",
+            primary_keys=["key", "child_key"],
+            fields={
+                "key": field.Field(field.String, primary_key=True, name="key"),
+                "child_key": field.Field(
+                    field.String, primary_key=True, name="child_key"
+                ),
+            },
+            interleaved=models.SmallTestModel,
+        )
         test_update.validate()
 
         test_model_ddl = (
@@ -140,6 +244,49 @@ class UpdateTest(unittest.TestCase):
         get_model.return_value = None
         new_model = models.RelationshipTestModel
         test_update = update.CreateTable(new_model)
+        test_update.validate()
+        print(test_update.ddl())
+
+        test_model_ddl = (
+            "CREATE TABLE RelationshipTestModel ("
+            "parent_key STRING(MAX) NOT NULL, "
+            "child_key STRING(MAX) NOT NULL, "
+            "CONSTRAINT parent FOREIGN KEY (parent_key) REFERENCES spanner_orm.tests.models.SmallTestModel (key), "
+            "CONSTRAINT parents FOREIGN KEY (parent_key) REFERENCES spanner_orm.tests.models.SmallTestModel (key), "
+            "CONSTRAINT fk_multicolumn FOREIGN KEY (parent_key, parent_key2) REFERENCES spanner_orm.tests.models.SmallTestModel (key, key2)) "
+            "PRIMARY KEY (parent_key, child_key)"
+        )
+        self.assertEqual(test_update.ddl(), test_model_ddl)
+
+    @mock.patch("spanner_orm.admin.metadata.SpannerMetadata.model")
+    def test_create_table_foreign_keys_no_model(self, get_model):
+        get_model.return_value = None
+        test_update = update.CreateTable(
+            table_name="RelationshipTestModel",
+            primary_keys=["parent_key", "child_key"],
+            fields={
+                "parent_key": field.Field(
+                    field.String, primary_key=True, name="parent_key"
+                ),
+                "child_key": field.Field(
+                    field.String, primary_key=True, name="child_key"
+                ),
+            },
+            relations={
+                "parent": relationship.Relationship(
+                    "spanner_orm.tests.models.SmallTestModel",
+                    {"parent_key": "key"},
+                    single=True,
+                ),
+                "parents": relationship.Relationship(
+                    "spanner_orm.tests.models.SmallTestModel", {"parent_key": "key"}
+                ),
+                "fk_multicolumn": relationship.Relationship(
+                    "spanner_orm.tests.models.SmallTestModel",
+                    {"parent_key": "key", "parent_key2": "key2"},
+                ),
+            },
+        )
         test_update.validate()
         print(test_update.ddl())
 


### PR DESCRIPTION
Migrations should use schema definition frozen in time at the time of creation so that updating models code doesn't automatically affect a historical migration.

- Also check black formatting in tests